### PR TITLE
50fps is now the default

### DIFF
--- a/run/nobody/start.sh
+++ b/run/nobody/start.sh
@@ -38,7 +38,7 @@ do
 
 		echo "[info] Running get_iplayer..."
 		# run get_iplayer for show, saving to incomplete folder
-		/usr/bin/get_iplayer --profile-dir /config --get --nopurge --modes=tvbest,radiobest --fps50 --file-prefix="${show_name} - <senum> - <episodeshort>" "${show_name}" --output "/data/get_iplayer/incomplete/${show_name}"
+		/usr/bin/get_iplayer --profile-dir /config --get --nopurge --modes=tvbest,radiobest --file-prefix="${show_name} - <senum> - <episodeshort>" "${show_name}" --output "/data/get_iplayer/incomplete/${show_name}"
 
 	done
 


### PR DESCRIPTION
This flag has been removed from get-iplayer
https://github.com/get-iplayer/get_iplayer/commit/ad6ad1e561e1b07f41ad16bb7271ec101f5f9baf

This is causing errors:

```
2018-05-14 22:20:50,992 DEBG 'get-iplayer' stderr output:
Unknown option: fps50
```