### PR TITLE
Update start.sh to make prefs changes to config folder

### DIFF
--- a/run/nobody/start.sh
+++ b/run/nobody/start.sh
@@ -71,7 +71,7 @@ function start() {
 	mkdir -p "/data/completed"
 
 	# set locations for ffmpeg and atomicparsley
-	/usr/bin/get_iplayer --prefs-add --ffmpeg='/usr/sbin/ffmpeg' --atomicparsley='/usr/sbin/atomicparsley'
+	/usr/bin/get_iplayer --profile-dir /config --prefs-add --ffmpeg='/usr/sbin/ffmpeg' --atomicparsley='/usr/sbin/atomicparsley'
 
 	while true; do
 


### PR DESCRIPTION
Hey, I noticed `WARNING: Required AtomicParsley utility not found - cannot tag MP4 file` during the "normal" run with start.sh

I think this is because the prefs command was writing to `/home/nobody/.get_iplayer/config` rather than the intended config directory from the configuration which is specified later with `--profile-dir`

Solution: add `--profile-dir` to the `prefs-add` command so the future commands, with that set, can pick it up